### PR TITLE
Implement auth with access and refresh tokens

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+PyJWT

--- a/src/README.md
+++ b/src/README.md
@@ -5,20 +5,22 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Register and log in teachers with access + refresh tokens
+- Refresh and revoke sessions (logout)
+- Sign up and unregister students for activities (protected endpoints)
 
 ## Getting Started
 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
 2. Run the application:
 
    ```
-   python app.py
+   uvicorn app:app --reload
    ```
 
 3. Open your browser and go to:
@@ -27,10 +29,30 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 ## API Endpoints
 
-| Method | Endpoint                                                          | Description                                                         |
-| ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| Method | Endpoint                                                              | Description                                                         |
+| ------ | --------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| POST   | `/auth/register`                                                      | Register a teacher account                                          |
+| POST   | `/auth/login`                                                         | Login and receive access + refresh tokens                           |
+| POST   | `/auth/refresh`                                                       | Exchange a valid refresh token for a new access + refresh token     |
+| POST   | `/auth/logout`                                                        | Revoke a refresh token session                                      |
+| GET    | `/activities`                                                         | Get all activities with their details and current participant count |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu`    | Protected: sign up for an activity                                  |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Protected: unregister from an activity                              |
+
+## Authentication Notes
+
+- Use `Authorization: Bearer <access_token>` for protected write endpoints.
+- Access token expiration defaults to 15 minutes.
+- Refresh token expiration defaults to 7 days.
+- `POST /auth/refresh` rotates refresh tokens and revokes the previous session token.
+- `POST /auth/logout` revokes the active refresh token.
+
+## Default Teacher Account
+
+For local development, a pre-seeded teacher user is available:
+
+- Email: `teacher@mergington.edu`
+- Password: `Teach3rPass!`
 
 ## Data Model
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -13,6 +13,36 @@
     </header>
 
     <main>
+      <section id="auth-container">
+        <h3>Teacher Authentication</h3>
+        <form id="register-form">
+          <div class="form-group">
+            <label for="register-email">Email:</label>
+            <input type="email" id="register-email" required placeholder="teacher@mergington.edu" />
+          </div>
+          <div class="form-group">
+            <label for="register-password">Password:</label>
+            <input type="password" id="register-password" required minlength="8" />
+          </div>
+          <button type="submit">Register</button>
+        </form>
+
+        <form id="login-form">
+          <div class="form-group">
+            <label for="login-email">Email:</label>
+            <input type="email" id="login-email" required placeholder="teacher@mergington.edu" />
+          </div>
+          <div class="form-group">
+            <label for="login-password">Password:</label>
+            <input type="password" id="login-password" required minlength="8" />
+          </div>
+          <button type="submit">Login</button>
+        </form>
+
+        <button id="logout-btn" type="button">Logout</button>
+        <div id="auth-message" class="hidden"></div>
+      </section>
+
       <section id="activities-container">
         <h3>Available Activities</h3>
         <div id="activities-list">


### PR DESCRIPTION
## Summary
- add registration, login, refresh, and logout endpoints
- issue JWT access and refresh tokens with refresh-session revocation/rotation
- protect signup/unregister endpoints with bearer access-token auth
- add minimal auth UI (register/login/logout) and token-aware API calls
- update docs and requirements for PyJWT

## Validation
- verified protected signup works with bearer token (200)
- verified protected signup without token returns 401
- verified refresh endpoint returns new tokens (200)
